### PR TITLE
通知調査用のログを削除

### DIFF
--- a/app/services/medication_notifier.rb
+++ b/app/services/medication_notifier.rb
@@ -20,16 +20,6 @@ class MedicationNotifier
   def notify
     return unless notification_target?
 
-    Rails.logger.info(
-      '[NOTIFY] ' \
-      "schedule_id=#{@medication_schedule.id} " \
-      "time_id=#{@medication_time.id} " \
-      "title=#{@medication_schedule.title} " \
-      "time=#{@medication_time.time} " \
-      "current_time=#{@current_time} " \
-      "first=#{first_notification?} " \
-      "reminder=#{reminder_notification?}"
-    )
     return if already_taken?
     return if reminder_notification? && !@user.reminder_enabled?
     return unless @user.line_bot_connected?


### PR DESCRIPTION
通知の重複送信を調査するために追加していたログを削除しました。
原因はローカル環境で定期実行プロセスが動作していたことによるもので、調査後はローカル環境で通知が発生しないことを確認できたため、不要になったログを削除しています。